### PR TITLE
Fix RangeCalendarHeading slot binding

### DIFF
--- a/components/ui/range-calendar/RangeCalendarHeading.vue
+++ b/components/ui/range-calendar/RangeCalendarHeading.vue
@@ -16,12 +16,12 @@ const forwardedProps = useForwardProps(delegatedProps)
 
 <template>
   <RangeCalendarHeading
-    v-slot="{ headingValue }"
+    v-slot="slotProps"
     :class="cn('text-sm font-medium', props.class)"
     v-bind="forwardedProps"
   >
-    <slot :heading-value>
-      {{ headingValue }}
+    <slot :heading-value="slotProps.headingValue">
+      {{ slotProps.headingValue }}
     </slot>
   </RangeCalendarHeading>
 </template>


### PR DESCRIPTION
## Summary
- fix slot attribute for RangeCalendarHeading so the heading value passes correctly

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Command failed with exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_683f44d289b883309a728fa9016015e2